### PR TITLE
option -t to enable search for public link token

### DIFF
--- a/lib/Command/ListShares.php
+++ b/lib/Command/ListShares.php
@@ -78,16 +78,22 @@ class ListShares extends Command {
 				InputOption::VALUE_OPTIONAL,
 				'Will only consider the given path'
 			)->addOption(
+				'token',
+				't',
+				InputOption::VALUE_OPTIONAL,
+				'Will only consider the given token'
+			)->addOption(
 				'filter',
 				'f',
 				InputOption::VALUE_OPTIONAL,
-				'Filter shares, possible values: owner, initiator, recipient'
+				'Filter shares, possible values: owner, initiator, recipient, token'
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$user = $input->getOption('user');
 		$path = $input->getOption('path');
+		$token = $input->getOption('token');
 		$filter = $input->getOption('filter');
 
 		if ($filter === 'owner') {
@@ -100,16 +106,16 @@ class ListShares extends Command {
 			$filter = SharesList::FILTER_NONE;
 		}
 
-		if ($user === null) {
+		if ($user === null && $token === null) {
 			$shares = [];
-			$this->userManager->callForSeenUsers(function (IUser $user) use ($path, $filter, &$shares) {
-				$tmp = $this->sharesList->getFormattedShares($user->getUID(), $filter, $path);
+			$this->userManager->callForSeenUsers(function (IUser $user) use ($token, $path, $filter, &$shares) {
+				$tmp = $this->sharesList->getFormattedShares($user->getUID(), $filter, $path, $token);
 				foreach ($tmp as $share) {
 					$shares[] = $share;
 				}
 			});
 		} else {
-			$shares = iter\toArray($this->sharesList->getFormattedShares($user, $filter, $path));
+			$shares = iter\toArray($this->sharesList->getFormattedShares($user = "", $filter, $path, $token));
 		}
 
 		$output->writeln(json_encode($shares, JSON_PRETTY_PRINT));

--- a/lib/Service/SharesList.php
+++ b/lib/Service/SharesList.php
@@ -41,6 +41,7 @@ class SharesList {
 	const FILTER_OWNER = 1;
 	const FILTER_INITIATOR = 2;
 	const FILTER_RECIPIENT = 3;
+	const FILTER_TOKEN = 4;
 
 	/** @var ShareManager */
 	private $shareManager;
@@ -69,7 +70,7 @@ class SharesList {
 		];
 	}
 
-	public function get(string $userId, int $filter, string $path = null): \Iterator {
+	public function get(string $userId, int $filter, string $path = null, string $token = null): \Iterator {
 		$shares = $this->getShares($userId);
 
 		// If path is set. Filter for the current user
@@ -90,6 +91,9 @@ class SharesList {
 				}
 				return false;
 			}, $shares);
+		}
+		if ($token !== null) {
+                        $shares = [$this->shareManager->getShareByToken($token)];
 		}
 
 		if ($filter === self::FILTER_OWNER) {
@@ -131,7 +135,7 @@ class SharesList {
 	 * This allows us to build a list of subfiles/folder that are shared
 	 * as well
 	 */
-	public function getSub(string $userId, int $filter, string $path): \Iterator {
+	public function getSub(string $userId, int $filter, string $path, string $token): \Iterator {
 		$shares = $this->shareManager->getAllShares();
 
 		// If path is set. Filter for the current user
@@ -152,6 +156,9 @@ class SharesList {
 				}
 				return false;
 			}, $shares);
+		}
+		if ($token !== null) {
+                        $shares = [$this->shareManager->getShareByToken($token)];
 		}
 
 		if ($filter === self::FILTER_OWNER) {
@@ -187,8 +194,8 @@ class SharesList {
 		return $shares;
 	}
 
-	public function getFormattedShares(string $userId, int $filter, string $path = null): \Iterator {
-		$shares = $this->get($userId, $filter, $path);
+	public function getFormattedShares(string $userId, int $filter, string $path = null, string $token = null): \Iterator {
+		$shares = $this->get($userId, $filter, $path, $token);
 
 		$formattedShares = iter\map(function (IShare $share) {
 			return $this->formatShare($share);

--- a/lib/Service/SharesList.php
+++ b/lib/Service/SharesList.php
@@ -158,7 +158,7 @@ class SharesList {
 			}, $shares);
 		}
 		if ($token !== null) {
-                        $shares = [$this->shareManager->getShareByToken($token)];
+			$shares = [$this->shareManager->getShareByToken($token)];
 		}
 
 		if ($filter === self::FILTER_OWNER) {


### PR DESCRIPTION
A customer was asking where a public link was pointing. We used sharelisting to find the original folder and owner/initiator. But for finding it we had to list all shares. In big installations this can take hours. That's why we added the possibility to search for tokens.

```
$ occ sharing:list -h
Description:
  List who has access to shares by owner

Usage:
  sharing:list [options]

Options:
  -u, --user[=USER]      Will list shares of the given user
  -p, --path[=PATH]      Will only consider the given path
  -t, --token[=TOKEN]    Will only consider the given token
  -f, --filter[=FILTER]  Filter shares, possible values: owner, initiator, recipient, token
  -h, --help             Display this help message
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi             Force ANSI output
      --no-ansi          Disable ANSI output
  -n, --no-interaction   Do not ask any interactive question
      --no-warnings      Skip global warnings, show command output only
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

$ occ sharing:list -t Bn2Q8pin3LZATJD
[
    {
        "id": "124927",
        "file_id": 1910428,
        "owner": "testuser",
        "initiator": "testuser",
        "time": "2021-04-07T08:50:02+00:00",
        "permissions": 1,
        "path": "\/test",
        "name": "test",
        "is_directory": true,
        "type": "link",
        "token": "Bn2Q8pin3LZATJD"
    }
]
```