### PR TITLE
Fix filter by user listing

### DIFF
--- a/lib/Command/ListShares.php
+++ b/lib/Command/ListShares.php
@@ -117,7 +117,7 @@ class ListShares extends Base {
 				}
 			});
 		} else {
-			$shares = iter\toArray($this->sharesList->getFormattedShares($user = "", $filter, $path, $token));
+			$shares = iter\toArray($this->sharesList->getFormattedShares($user, $filter, $path, $token));
 		}
 
 		$output->writeln(json_encode($shares, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));

--- a/lib/Service/SharesList.php
+++ b/lib/Service/SharesList.php
@@ -190,7 +190,7 @@ class SharesList {
 		return $shares;
 	}
 
-	public function getFormattedShares(string $userId, int $filter, string $path = null, string $token = null): \Iterator {
+	public function getFormattedShares(string $userId = '', int $filter, string $path = null, string $token = null): \Iterator {
 		$shares = $this->get($userId, $filter, $path, $token);
 
 		$formattedShares = iter\map(function (IShare $share) {


### PR DESCRIPTION
The user argument passed with `--user=<user>` was not being used for filtering as the user was always set to the return value of the empty string assignment added in https://github.com/nextcloud/sharelisting/pull/272 and was likely supposed to be a default value set in the function declaration