### PR TITLE
Make nullable explicit

### DIFF
--- a/lib/Service/SharesList.php
+++ b/lib/Service/SharesList.php
@@ -76,7 +76,7 @@ class SharesList {
 		];
 	}
 
-	public function get(?string $userId, int $filter, string $path = null, string $token = null): \Iterator {
+	public function get(?string $userId, int $filter, ?string $path = null, ?string $token = null): \Iterator {
 		$shares = $this->getShares($userId);
 
 		// If path is set. Filter for the current user
@@ -208,7 +208,7 @@ class SharesList {
 		return $shares;
 	}
 
-	public function getFormattedShares(string $userId = null, int $filter = self::FILTER_NONE, string $path = null, string $token = null): \Iterator {
+	public function getFormattedShares(?string $userId = null, int $filter = self::FILTER_NONE, ?string $path = null, ?string $token = null): \Iterator {
 		$shares = $this->get($userId, $filter, $path, $token);
 
 		$formattedShares = iter\map(function (IShare $share): array {


### PR DESCRIPTION
Silence messages:

PHP Deprecated:  OCA\ShareListing\Service\SharesList::get(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in /var/www/nextcloud/apps/sharelisting/lib/Service/SharesList.php on line 79
PHP Deprecated:  OCA\ShareListing\Service\SharesList::get(): Implicitly marking parameter $token as nullable is deprecated, the explicit nullable type must be used instead in /var/www/nextcloud/apps/sharelisting/lib/Service/SharesList.php on line 79
PHP Deprecated:  OCA\ShareListing\Service\SharesList::getFormattedShares(): Implicitly marking parameter $userId as nullable is deprecated, the explicit nullable type must be used instead in /var/www/nextcloud/apps/sharelisting/lib/Service/SharesList.php on line 211
PHP Deprecated:  OCA\ShareListing\Service\SharesList::getFormattedShares(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in /var/www/nextcloud/apps/sharelisting/lib/Service/SharesList.php on line 211
PHP Deprecated:  OCA\ShareListing\Service\SharesList::getFormattedShares(): Implicitly marking parameter $token as nullable is deprecated, the explicit nullable type must be used instead in /var/www/nextcloud/apps/sharelisting/lib/Service/SharesList.php on line 211

See:

https://github.com/nextcloud/sharelisting/issues/535 https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated